### PR TITLE
Fix URL, update refpolicy patches and dependencies

### DIFF
--- a/recipes-security/refpolicy/refpolicy-git/poky-fc-update-alternatives_bash.patch
+++ b/recipes-security/refpolicy/refpolicy-git/poky-fc-update-alternatives_bash.patch
@@ -1,24 +1,12 @@
-From 845518a6f196e6e8c49ba38791c85e17276920e1 Mon Sep 17 00:00:00 2001
-From: Mark Hatle <mark.hatle@windriver.com>
-Date: Thu, 14 Sep 2017 15:02:23 -0500
-Subject: [PATCH 3/4] fix update-alternatives for hostname
-
-Upstream-Status: Inappropriate [only for Poky]
-
-Signed-off-by: Mark Hatle <mark.hatle@windriver.com>
----
- policy/modules/system/corecommands.fc |    1 +
- 1 file changed, 1 insertion(+)
-
-Index: refpolicy/policy/modules/kernel/corecommands.fc
-===================================================================
---- refpolicy.orig/policy/modules/kernel/corecommands.fc
-+++ refpolicy/policy/modules/kernel/corecommands.fc
-@@ -6,6 +6,7 @@
- /bin/d?ash			--	gen_context(system_u:object_r:shell_exec_t,s0)
- /bin/bash			--	gen_context(system_u:object_r:shell_exec_t,s0)
- /bin/bash2			--	gen_context(system_u:object_r:shell_exec_t,s0)
-+/bin/bash\.bash			--	gen_context(system_u:object_r:shell_exec_t,s0)
- /bin/fish			--	gen_context(system_u:object_r:shell_exec_t,s0)
- /bin/ksh.*			--	gen_context(system_u:object_r:shell_exec_t,s0)
- /bin/mksh			--	gen_context(system_u:object_r:shell_exec_t,s0)
+diff --git a/policy/modules/kernel/corecommands.fc b/policy/modules/kernel/corecommands.fc
+index f2e4f51..c39912d 100644
+--- a/policy/modules/kernel/corecommands.fc
++++ b/policy/modules/kernel/corecommands.fc
+@@ -141,6 +141,7 @@ ifdef(`distro_gentoo',`
+ /usr/bin/d?ash			--	gen_context(system_u:object_r:shell_exec_t,s0)
+ /usr/bin/bash			--	gen_context(system_u:object_r:shell_exec_t,s0)
+ /usr/bin/bash2			--	gen_context(system_u:object_r:shell_exec_t,s0)
++/usr/bin\.bash			--	gen_context(system_u:object_r:shell_exec_t,s0)
+ /usr/bin/fish			--	gen_context(system_u:object_r:shell_exec_t,s0)
+ /usr/bin/git-shell		--	gen_context(system_u:object_r:shell_exec_t,s0)
+ /usr/bin/insmod_ksymoops_clean	--	gen_context(system_u:object_r:bin_t,s0)

--- a/recipes-security/refpolicy/refpolicy-git/poky-policy-add-rules-for-var-log-symlink-apache.patch
+++ b/recipes-security/refpolicy/refpolicy-git/poky-policy-add-rules-for-var-log-symlink-apache.patch
@@ -1,31 +1,12 @@
-From ed2b0a00e2fb78056041b03c7e198e8f5adaf939 Mon Sep 17 00:00:00 2001
-From: Xin Ouyang <Xin.Ouyang@windriver.com>
-Date: Thu, 22 Aug 2013 19:36:44 +0800
-Subject: [PATCH 3/6] add rules for the symlink of /var/log - apache2
-
-We have added rules for the symlink of /var/log in logging.if,
-while apache.te uses /var/log but does not use the interfaces in
-logging.if. So still need add a individual rule for apache.te.
-
-Upstream-Status: Inappropriate [only for Poky]
-
-Signed-off-by: Xin Ouyang <Xin.Ouyang@windriver.com>
-Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>
----
- policy/modules/contrib/apache.te |    1 +
- 1 file changed, 1 insertion(+)
-
+diff --git a/policy/modules/contrib/apache.te b/policy/modules/contrib/apache.te
+index fcf795f..529057c 100644
 --- a/policy/modules/contrib/apache.te
 +++ b/policy/modules/contrib/apache.te
-@@ -407,10 +407,11 @@ allow httpd_t httpd_lock_t:file manage_f
- files_lock_filetrans(httpd_t, httpd_lock_t, { file dir })
- 
- manage_dirs_pattern(httpd_t, httpd_log_t, httpd_log_t)
- manage_files_pattern(httpd_t, httpd_log_t, httpd_log_t)
+@@ -412,6 +412,7 @@ create_files_pattern(httpd_t, httpd_log_t, httpd_log_t)
+ read_files_pattern(httpd_t, httpd_log_t, httpd_log_t)
+ setattr_files_pattern(httpd_t, httpd_log_t, httpd_log_t)
  read_lnk_files_pattern(httpd_t, httpd_log_t, httpd_log_t)
 +read_lnk_files_pattern(httpd_t, var_log_t, var_log_t)
  logging_log_filetrans(httpd_t, httpd_log_t, file)
  
  allow httpd_t httpd_modules_t:dir list_dir_perms;
- mmap_files_pattern(httpd_t, httpd_modules_t, httpd_modules_t)
- read_files_pattern(httpd_t, httpd_modules_t, httpd_modules_t)

--- a/recipes-security/refpolicy/refpolicy-minimum/0001-refpolicy-minimum-systemd-unconfined-lib-add-systemd.patch
+++ b/recipes-security/refpolicy/refpolicy-minimum/0001-refpolicy-minimum-systemd-unconfined-lib-add-systemd.patch
@@ -35,13 +35,10 @@ diff --git a/policy/modules/system/init.te b/policy/modules/system/init.te
 index d710fb0..f9d7114 100644
 --- a/policy/modules/system/init.te
 +++ b/policy/modules/system/init.te
-@@ -1100,4 +1100,8 @@ optional_policy(`
- # systemd related allow rules
+@@ -1114,3 +1114,7 @@ optional_policy(`
  allow kernel_t init_t:process dyntransition;
  allow devpts_t device_t:filesystem associate;
--allow init_t self:capability2 block_suspend;
-\ No newline at end of file
-+allow init_t self:capability2 block_suspend;
+ allow init_t self:capability2 block_suspend;
 +allow init_t self:capability2 audit_read;
 +
 +allow initrc_t init_t:system { start status };

--- a/recipes-security/refpolicy/refpolicy-minimum/0007-refpolicy-minimum-systemd-fix-for-login-journal-serv.patch
+++ b/recipes-security/refpolicy/refpolicy-minimum/0007-refpolicy-minimum-systemd-fix-for-login-journal-serv.patch
@@ -49,15 +49,12 @@ diff --git a/policy/modules/system/init.te b/policy/modules/system/init.te
 index 19a7a20..cefa59d 100644
 --- a/policy/modules/system/init.te
 +++ b/policy/modules/system/init.te
-@@ -1105,3 +1105,8 @@ allow init_t self:capability2 audit_read;
+@@ -1105,3 +1105,5 @@ allow init_t self:capability2 audit_read;
  
  allow initrc_t init_t:system { start status reboot };
  allow initrc_t init_var_run_t:service { start status };
 +
 +allow initrc_t init_var_run_t:service stop;
-+allow initrc_t init_t:dbus send_msg;
-+
-+allow init_t initrc_t:dbus { send_msg acquire_svc };
 diff --git a/policy/modules/system/locallogin.te b/policy/modules/system/locallogin.te
 index 09ec33f..be25c82 100644
 --- a/policy/modules/system/locallogin.te

--- a/recipes-security/refpolicy/refpolicy-minimum_git.bb
+++ b/recipes-security/refpolicy/refpolicy-minimum_git.bb
@@ -18,7 +18,7 @@ CORE_POLICY_MODULES = "unconfined \
 	init mount modutils getty authlogin locallogin \
 	"
 #systemd dependent policy modules
-CORE_POLICY_MODULES += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'clock systemd udev', '', d)}"
+CORE_POLICY_MODULES += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'clock systemd udev fstools', '', d)}"
 
 # nscd caches libc-issued requests to the name service.
 # Without nscd.pp, commands want to use these caches will be blocked.

--- a/recipes-security/refpolicy/refpolicy-targeted/refpolicy-fix-optional-issue-on-sysadm-module_2.20170204.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/refpolicy-fix-optional-issue-on-sysadm-module_2.20170204.patch
@@ -1,0 +1,72 @@
+Subject: [PATCH] refpolicy: fix optional issue on sysadm module
+
+init and locallogin modules have a depend for sysadm module because
+they have called sysadm interfaces(sysadm_shell_domtrans). Since
+sysadm is not a core module, we could make the sysadm_shell_domtrans
+calls optionally by optional_policy.
+
+So, we could make the minimum policy without sysadm module.
+
+Upstream-Status: pending
+
+Signed-off-by: Xin Ouyang <Xin.Ouyang@windriver.com>
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>
+---
+ policy/modules/system/init.te       | 14 ++++++++------
+ policy/modules/system/locallogin.te |  4 +++-
+ 2 files changed, 11 insertions(+), 7 deletions(-)
+
+--- a/policy/modules/system/init.te
++++ b/policy/modules/system/init.te
+@@ -300,16 +300,18 @@ ifdef(`init_systemd',`
+ 
+ 	optional_policy(`
+ 		modutils_domtrans_insmod(init_t)
+ 	')
+ ',`
+-	tunable_policy(`init_upstart',`
+-		corecmd_shell_domtrans(init_t, initrc_t)
+-	',`
+-		# Run the shell in the sysadm role for single-user mode.
+-		# causes problems with upstart
+-		sysadm_shell_domtrans(init_t)
++	optional_policy(`
++		tunable_policy(`init_upstart',`
++			corecmd_shell_domtrans(init_t, initrc_t)
++		',`
++			# Run the shell in the sysadm role for single-user mode.
++			# causes problems with upstart
++			sysadm_shell_domtrans(init_t)
++		')
+ 	')
+ ')
+ 
+ ifdef(`distro_debian',`
+ 	fs_tmpfs_filetrans(init_t, initctl_t, fifo_file, "initctl")
+@@ -1109,6 +1111,6 @@ optional_policy(`
+ ')
+ 
+ # systemd related allow rules
+ allow kernel_t init_t:process dyntransition;
+ allow devpts_t device_t:filesystem associate;
+-allow init_t self:capability2 block_suspend;
+\ No newline at end of file
++allow init_t self:capability2 block_suspend;
+--- a/policy/modules/system/locallogin.te
++++ b/policy/modules/system/locallogin.te
+@@ -244,11 +244,13 @@ seutil_read_default_contexts(sulogin_t)
+ userdom_use_unpriv_users_fds(sulogin_t)
+ 
+ userdom_search_user_home_dirs(sulogin_t)
+ userdom_use_user_ptys(sulogin_t)
+ 
+-sysadm_shell_domtrans(sulogin_t)
++optional_policy(`
++	sysadm_shell_domtrans(sulogin_t)
++')
+ 
+ # suse and debian do not use pam with sulogin...
+ ifdef(`distro_suse', `define(`sulogin_no_pam')')
+ ifdef(`distro_debian', `define(`sulogin_no_pam')')
+ 

--- a/recipes-security/refpolicy/refpolicy-targeted/refpolicy-remove-duplicate-type_transition_2.20170204.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/refpolicy-remove-duplicate-type_transition_2.20170204.patch
@@ -1,0 +1,46 @@
+From e1693b640f889818091c976a90041ea6a843fafd Mon Sep 17 00:00:00 2001
+From: Wenzong Fan <wenzong.fan@windriver.com>
+Date: Wed, 17 Feb 2016 08:35:51 -0500
+Subject: [PATCH] remove duplicate type_transition
+
+Remove duplicate type rules from init_t to init_script_file_type,
+they have been included by systemd policies. This also fixes the
+errors while installing modules for refpolicy-targeted if systemd
+support is enabled:
+
+| Conflicting type rules
+| Binary policy creation failed at line 327 of \
+  .../tmp/work/qemux86-poky-linux/refpolicy-targeted/git-r0/image\
+  /var/lib/selinux/targeted/tmp/modules/100/init/cil
+| Failed to generate binary
+| semodule:  Failed!
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>
+---
+ policy/modules/system/init.if | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/policy/modules/system/init.if
++++ b/policy/modules/system/init.if
+@@ -1268,16 +1268,16 @@ interface(`init_spec_domtrans_script',`
+ ##	</summary>
+ ## </param>
+ #
+ interface(`init_domtrans_script',`
+ 	gen_require(`
+-		type initrc_t;
++		type initrc_t, initrc_exec_t;
+ 		attribute init_script_file_type;
+ 	')
+ 
+ 	files_list_etc($1)
+-	domtrans_pattern($1, init_script_file_type, initrc_t)
++	domtrans_pattern($1, initrc_exec_t, initrc_t)
+ 
+ 	ifdef(`enable_mcs',`
+ 		range_transition $1 init_script_file_type:process s0;
+ 	')
+ 

--- a/recipes-security/refpolicy/refpolicy-targeted/refpolicy-unconfined_u-default-user_2.20170204.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/refpolicy-unconfined_u-default-user_2.20170204.patch
@@ -1,0 +1,222 @@
+Subject: [PATCH] refpolicy: make unconfined_u the default selinux user
+
+For targeted policy type, we define unconfined_u as the default selinux
+user for root and normal users, so users could login in and run most
+commands and services on unconfined domains.
+
+Also add rules for users to run init scripts directly, instead of via
+run_init.
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Xin Ouyang <Xin.Ouyang@windriver.com>
+Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+---
+ config/appconfig-mcs/seusers        |  4 ++--
+ policy/modules/roles/sysadm.te      |  1 +
+ policy/modules/system/init.if       | 47 ++++++++++++++++++++++++++++++-------
+ policy/modules/system/unconfined.te |  7 ++++++
+ policy/users                        | 16 +++++--------
+ 5 files changed, 55 insertions(+), 20 deletions(-)
+
+--- a/config/appconfig-mcs/seusers
++++ b/config/appconfig-mcs/seusers
+@@ -1,2 +1,3 @@
+-root:root:s0-mcs_systemhigh
+-__default__:user_u:s0
++root:unconfined_u:s0-mcs_systemhigh
++__default__:unconfined_u:s0
++
+--- a/policy/modules/roles/sysadm.te
++++ b/policy/modules/roles/sysadm.te
+@@ -41,10 +41,11 @@ init_reload(sysadm_t)
+ init_reboot_system(sysadm_t)
+ init_shutdown_system(sysadm_t)
+ init_start_generic_units(sysadm_t)
+ init_stop_generic_units(sysadm_t)
+ init_reload_generic_units(sysadm_t)
++init_script_role_transition(sysadm_r)
+ 
+ # Add/remove user home directories
+ userdom_manage_user_home_dirs(sysadm_t)
+ userdom_home_filetrans_user_home_dir(sysadm_t)
+ 
+--- a/policy/modules/system/init.if
++++ b/policy/modules/system/init.if
+@@ -1232,30 +1232,31 @@ interface(`init_script_file_entry_type',
+ ##	</summary>
+ ## </param>
+ #
+ interface(`init_spec_domtrans_script',`
+ 	gen_require(`
+-		type initrc_t, initrc_exec_t;
++		type initrc_t;
++		attribute init_script_file_type;
+ 	')
+ 
+ 	files_list_etc($1)
+-	spec_domtrans_pattern($1, initrc_exec_t, initrc_t)
++	spec_domtrans_pattern($1, init_script_file_type, initrc_t)
+ 
+ 	ifdef(`distro_gentoo',`
+ 		gen_require(`
+ 			type rc_exec_t;
+ 		')
+ 
+ 		domtrans_pattern($1, rc_exec_t, initrc_t)
+ 	')
+ 
+ 	ifdef(`enable_mcs',`
+-		range_transition $1 initrc_exec_t:process s0;
++		range_transition $1 init_script_file_type:process s0;
+ 	')
+ 
+ 	ifdef(`enable_mls',`
+-		range_transition $1 initrc_exec_t:process s0 - mls_systemhigh;
++		range_transition $1 init_script_file_type:process s0 - mls_systemhigh;
+ 	')
+ ')
+ 
+ ########################################
+ ## <summary>
+@@ -1267,22 +1268,23 @@ interface(`init_spec_domtrans_script',`
+ ##	</summary>
+ ## </param>
+ #
+ interface(`init_domtrans_script',`
+ 	gen_require(`
+-		type initrc_t, initrc_exec_t;
++		type initrc_t;
++		attribute init_script_file_type;
+ 	')
+ 
+ 	files_list_etc($1)
+-	domtrans_pattern($1, initrc_exec_t, initrc_t)
++	domtrans_pattern($1, init_script_file_type, initrc_t)
+ 
+ 	ifdef(`enable_mcs',`
+-		range_transition $1 initrc_exec_t:process s0;
++		range_transition $1 init_script_file_type:process s0;
+ 	')
+ 
+ 	ifdef(`enable_mls',`
+-		range_transition $1 initrc_exec_t:process s0 - mls_systemhigh;
++		range_transition $1 init_script_file_type:process s0 - mls_systemhigh;
+ 	')
+ ')
+ 
+ ########################################
+ ## <summary>
+@@ -2502,5 +2504,34 @@ interface(`init_reload_all_units',`
+ 		class service reload;
+ 	')
+ 
+ 	allow $1 systemdunit:service reload;
+ ')
++
++########################################
++## <summary>
++##	Transition to system_r when execute an init script
++## </summary>
++## <desc>
++##	<p>
++##	Execute a init script in a specified role
++##	</p>
++##	<p>
++##	No interprocess communication (signals, pipes,
++##	etc.) is provided by this interface since
++##	the domains are not owned by this module.
++##	</p>
++## </desc>
++## <param name="source_role">
++##	<summary>
++##	Role to transition from.
++##	</summary>
++## </param>
++#
++interface(`init_script_role_transition',`
++	gen_require(`
++		attribute init_script_file_type;
++	')
++
++	role_transition $1 init_script_file_type system_r;
++')
++
+--- a/policy/modules/system/unconfined.te
++++ b/policy/modules/system/unconfined.te
+@@ -18,10 +18,15 @@ init_system_domain(unconfined_t, unconfi
+ 
+ type unconfined_execmem_t;
+ type unconfined_execmem_exec_t;
+ init_system_domain(unconfined_execmem_t, unconfined_execmem_exec_t)
+ role unconfined_r types unconfined_execmem_t;
++role unconfined_r types unconfined_t;
++role system_r types unconfined_t;
++role_transition system_r unconfined_exec_t unconfined_r;
++allow system_r unconfined_r;
++allow unconfined_r system_r;
+ 
+ ########################################
+ #
+ # Local policy
+ #
+@@ -48,10 +53,12 @@ unconfined_domain(unconfined_t)
+ userdom_user_home_dir_filetrans_user_home_content(unconfined_t, { dir file lnk_file fifo_file sock_file })
+ 
+ ifdef(`direct_sysadm_daemon',`
+         optional_policy(`
+                 init_run_daemon(unconfined_t, unconfined_r)
++                init_domtrans_script(unconfined_t)
++                init_script_role_transition(unconfined_r)
+         ')
+ ',`
+         ifdef(`distro_gentoo',`
+                 seutil_run_runinit(unconfined_t, unconfined_r)
+                 seutil_init_script_run_runinit(unconfined_t, unconfined_r)
+--- a/policy/users
++++ b/policy/users
+@@ -13,37 +13,33 @@
+ # system_u is the user identity for system processes and objects.
+ # There should be no corresponding Unix user identity for system,
+ # and a user process should never be assigned the system user
+ # identity.
+ #
+-gen_user(system_u,, system_r, s0, s0 - mls_systemhigh, mcs_allcats)
++gen_user(system_u,, system_r unconfined_r, s0, s0 - mls_systemhigh, mcs_allcats)
+ 
+ #
+ # user_u is a generic user identity for Linux users who have no
+ # SELinux user identity defined.  The modified daemons will use
+ # this user identity in the security context if there is no matching
+ # SELinux user identity for a Linux user.  If you do not want to
+ # permit any access to such users, then remove this entry.
+ #
+ gen_user(user_u, user, user_r, s0, s0)
+-gen_user(staff_u, staff, staff_r sysadm_r ifdef(`enable_mls',`secadm_r auditadm_r'), s0, s0 - mls_systemhigh, mcs_allcats)
+-gen_user(sysadm_u, sysadm, sysadm_r, s0, s0 - mls_systemhigh, mcs_allcats)
++gen_user(staff_u, user, staff_r sysadm_r ifdef(`enable_mls',`secadm_r auditadm_r') unconfined_r, s0, s0 - mls_systemhigh, mcs_allcats)
++gen_user(sysadm_u, user, sysadm_r, s0, s0 - mls_systemhigh, mcs_allcats)
+ 
+ # Until order dependence is fixed for users:
+ ifdef(`direct_sysadm_daemon',`
+-        gen_user(unconfined_u, unconfined, unconfined_r system_r, s0, s0 - mls_systemhigh, mcs_allcats)
++        gen_user(unconfined_u, user, unconfined_r system_r, s0, s0 - mls_systemhigh, mcs_allcats)
+ ',`
+-        gen_user(unconfined_u, unconfined, unconfined_r, s0, s0 - mls_systemhigh, mcs_allcats)
++        gen_user(unconfined_u, user, unconfined_r, s0, s0 - mls_systemhigh, mcs_allcats)
+ ')
+ 
+ #
+ # The following users correspond to Unix identities.
+ # These identities are typically assigned as the user attribute
+ # when login starts the user shell.  Users with access to the sysadm_r
+ # role should use the staff_r role instead of the user_r role when
+ # not in the sysadm_r.
+ #
+-ifdef(`direct_sysadm_daemon',`
+-	gen_user(root, sysadm, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r') system_r, s0, s0 - mls_systemhigh, mcs_allcats)
+-',`
+-	gen_user(root, sysadm, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r'), s0, s0 - mls_systemhigh, mcs_allcats)
+-')
++gen_user(root, user, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r') unconfined_r system_r, s0, s0 - mls_systemhigh, mcs_allcats)

--- a/recipes-security/refpolicy/refpolicy-targeted_2.20170204.bb
+++ b/recipes-security/refpolicy/refpolicy-targeted_2.20170204.bb
@@ -14,8 +14,16 @@ POLICY_MLS_SENS = "0"
 
 include refpolicy_${PV}.inc
 
-SRC_URI += " \
+SRC_URI += "${@bb.utils.contains('${PV}', '2.20170805', '${PATCH_2.20170805}', '${PATCH_2.20170204}', d)}"
+
+PATCH_2.20170805 = " \
             file://refpolicy-fix-optional-issue-on-sysadm-module.patch \
             file://refpolicy-unconfined_u-default-user.patch \
             ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://refpolicy-remove-duplicate-type_transition.patch', '', d)} \
+           "
+
+PATCH_2.20170204 = " \
+            file://refpolicy-fix-optional-issue-on-sysadm-module_2.20170204.patch \
+            file://refpolicy-unconfined_u-default-user_2.20170204.patch \
+            ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://refpolicy-remove-duplicate-type_transition_2.20170204.patch', '', d)} \
            "


### PR DESCRIPTION
* audit_2.7.6.bb : fix error [gzip: stdin: not in gzip format] and checksum
* refpolicy-minimum_git.bb : fix [Failed to resolve typeattributeset statement], dependency for "fsadm" in init.pp
* refpolicy-targeted_2.20170204.bb : added version dependent patches
* patches : separate patches for release 2.20170204 version and 2.20170805+git version

Signed-off-by: Sajjad Ahmed <sajjad_ahmed@mentor.com>
Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>